### PR TITLE
Add C allocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.8 // indirect
+	github.com/nsrip-dd/cgotraceback v0.0.0-20220518170113-75f7f93d1852 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.14.8 h1:gDp86IdQsN/xWjIEmr9MF6o9mpksUgh0fu+9ByFxzIU=
 github.com/mattn/go-sqlite3 v1.14.8/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/nsrip-dd/cgotraceback v0.0.0-20220518170113-75f7f93d1852 h1:8CjT9+ILnlLyfXWRRL0YtpU0cV5aKVN28VLC/oIOIy8=
+github.com/nsrip-dd/cgotraceback v0.0.0-20220518170113-75f7f93d1852/go.mod h1:4kIM7OHR40a02TyG1YhrNIxBbvFZsF4KT1vj/+uQTbY=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/jackc/pgx/v4/stdlib"
+	_ "github.com/nsrip-dd/cgotraceback"
 	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/julienschmidt/httprouter"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/jackc/pgx/v4/stdlib"
-	_ "github.com/nsrip-dd/cgotraceback"
 	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/julienschmidt/httprouter"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"

--- a/main_cmemprof.go
+++ b/main_cmemprof.go
@@ -1,0 +1,11 @@
+//go:build experimental_cmemprof
+// +build experimental_cmemprof
+
+package main
+
+// Only enable cgotraceback (which adds a 3rd-party dependency on libunwind) if
+// we're profiling C allocations
+
+import (
+	_ "github.com/nsrip-dd/cgotraceback"
+)

--- a/posts_handler.go
+++ b/posts_handler.go
@@ -15,7 +15,9 @@ import (
 #cgo experimental_cmemprof CFLAGS: -DUSE_GMP
 #include <stdlib.h>
 
+#ifdef USE_GMP
 #include <gmp.h>
+#endif
 
 long *side_effect;
 

--- a/posts_handler.go
+++ b/posts_handler.go
@@ -5,20 +5,39 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
 )
 
 /*
+#cgo LDFLAGS: -lgmp
+#include <stdlib.h>
+
+#include <gmp.h>
+
+long *side_effect;
 
 // cpuHog tries to waste about 1ms of CPU time.
 long cpuHog() {
-	long sum = 0;
+	// call plain malloc, which gives us an invocation statically built in
+	// to the program
+	long *p = malloc(1000*sizeof(long));
+	side_effect = p;
+	free(p);
+
+	// Do some GMP stuff to get memory allocation from a third-party shared
+	// library. We use p to make sure all the operations in this function
+	// are intertwined and hopefully don't get optimized away
+	mpz_t foo;
+	mpz_init_set_ui(foo, (unsigned long int) p);
+	mpz_pow_ui(foo, foo, 42);
+
+	long sum = mpz_odd_p(foo);
 	for (long i = 0; i < 1000000; i++) {
 		sum += i % 10;
 	}
+	mpz_clear(foo);
 	return sum;
 }
 */
@@ -94,15 +113,17 @@ func (h *PostsHandler) cpuWork(posts []*Post) ([]byte, error) {
 func cgoCPUHog(posts []*Post, data *[]byte, wg *sync.WaitGroup, stop chan struct{}) {
 	defer wg.Done()
 
+	// Call malloc through C.malloc because this is a special case that has
+	// to be profiled without going through any Go functions
+	p := C.malloc(4096)
+	defer C.free(p)
 loop:
 	for {
 		select {
 		case <-stop:
 			break loop
 		default:
-			start := time.Now()
 			C.cpuHog()
-			fmt.Printf("time.Since(start): %v\n", time.Since(start))
 		}
 	}
 	var buf bytes.Buffer

--- a/posts_handler.go
+++ b/posts_handler.go
@@ -11,7 +11,8 @@ import (
 )
 
 /*
-#cgo LDFLAGS: -lgmp
+#cgo experimental_cmemprof LDFLAGS: -lgmp
+#cgo experimental_cmemprof CFLAGS: -DUSE_GMP
 #include <stdlib.h>
 
 #include <gmp.h>
@@ -26,18 +27,25 @@ long cpuHog() {
 	side_effect = p;
 	free(p);
 
+	long sum = 0;
+	#ifdef USE_GMP
 	// Do some GMP stuff to get memory allocation from a third-party shared
 	// library. We use p to make sure all the operations in this function
 	// are intertwined and hopefully don't get optimized away
 	mpz_t foo;
 	mpz_init_set_ui(foo, (unsigned long int) p);
 	mpz_pow_ui(foo, foo, 42);
+	sum = mpz_odd_p(foo);
+	#endif
 
-	long sum = mpz_odd_p(foo);
 	for (long i = 0; i < 1000000; i++) {
 		sum += i % 10;
 	}
+
+	#ifdef USE_GMP
 	mpz_clear(foo);
+	#endif
+
 	return sum;
 }
 */


### PR DESCRIPTION
To test C allocation profiling. There are three kinds of allocations:

	* Through C.malloc, which is a special case
	* Through plain malloc in C code
	* Through a third-party shared library (GMP)

Also add a cgo traceback import to get C call stacks.