### PR TITLE
chore: periodically run malloc_trim where available

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,8 @@ func run() error {
 
 	log.Printf("Starting up %s version %s at http %s", *serviceF, version, *addrF)
 
+	mallocTrimEvery(time.Minute)
+
 	if *traceF != "" {
 		log.Printf("Capturing executiong trace to %q", *traceF)
 		traceFile, err := os.Create(*traceF)

--- a/malloctrim_cgo.go
+++ b/malloctrim_cgo.go
@@ -1,0 +1,38 @@
+//go:build linux && cgo
+// +build linux,cgo
+
+package main
+
+import "time"
+
+/*
+#include <malloc.h>
+
+#ifdef __GLIBC__
+  int isGlibc = 1;
+#else
+  int isGlibc = 0;
+  int malloc_trim(size_t __pad) {
+    return 0;
+  }
+#endif
+*/
+import "C"
+
+// mallocTrimEvery executes the malloc_trim function on the given interval. It
+// does nothing if the platform is not linux, or the platform is not based on
+// GlibC (since malloc_trim is a GlibC extension). The purpose of this call is
+// to return unused pages to the system, instead of keeping them in the app's
+// RSS.
+func mallocTrimEvery(freq time.Duration) {
+	if C.isGlibc == 0 {
+		// Not GLIBC, so no malloc_trim...
+		return
+	}
+	go func() {
+		for {
+			time.Sleep(freq)
+			C.malloc_trim(0)
+		}
+	}()
+}

--- a/malloctrim_nocgo.go
+++ b/malloctrim_nocgo.go
@@ -1,0 +1,15 @@
+//go:build !linux || !cgo
+// +build !linux !cgo
+
+package main
+
+import "time"
+
+// mallocTrimEvery executes the malloc_trim function on the given interval. It
+// does nothing if the platform is not linux, or the platform is not based on
+// GlibC (since malloc_trim is a GlibC extension). The purpose of this call is
+// to return unused pages to the system, instead of keeping them in the app's
+// RSS.
+func mallocTrimEvery(time.Duration) {
+	// No malloc_trim is available on this platform...
+}


### PR DESCRIPTION
In an effort to investigate RSS growth, we try to run `malloc_trim` every minute (approximately) to try and see wether this results in a positive impact on the observed RSS growth pattern.